### PR TITLE
added core all.css

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -77,6 +77,7 @@ class renderer_plugin_s5 extends Doku_Renderer_xhtml {
 <meta name="defaultView" content="slideshow" />
 <meta name="controlVis" content="hidden" />
 <!-- style sheet links -->
+<link rel="stylesheet" href="'.DOKU_BASE.'lib/styles/all.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="'.DOKU_BASE.'lib/styles/screen.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="'.$this->base.$this->tpl.'/slides.css" type="text/css" media="projection" id="slideProj" />
 <link rel="stylesheet" href="'.$this->base.'default/outline.css" type="text/css" media="screen" id="outlineStyle" />


### PR DESCRIPTION
The old core `style.css` was not just renamed to `screen.css` (as
fixed by #9), but rather split into that and `all.css`. So that file
needs to be there as well (it includes, e.g. table and image
alignment classes and more).
