### PR TITLE
Header level to split slides is now chosen

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,4 @@
 <?php
 
 $conf['template']    = 'dokuwiki';
-
+$conf['maxHeaderLevelForNewSlide']    = 2;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,4 +1,5 @@
 <?php
 
 $meta['template'] = array('dirchoice','_dir' => DOKU_INC.'lib/plugins/s5/ui/');
-
+$meta['maxHeaderLevelForNewSlide'] = array('multichoice',
+                         '_choices' => array('2', '3', '4', '5'));

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,5 @@
 <?php
 
 $lang['template'] = 'The template to use for slide shows';
+$lang['maxHeaderLevelForNewSlide'] = 'Header level for new slide';
+

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -6,3 +6,4 @@
  */
 
 $lang['template'] = 'Thème à utiliser pour les diaporamas';
+$lang['maxHeaderLevelForNewSlide'] = 'Nouveau niveau d\'en-tête de diapositive';

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -7,3 +7,4 @@
  */
 
 $lang['template'] = 'スライドショー用のテンプレート';
+$lang['maxHeaderLevelForNewSlide'] = '新しいスライドヘッダーレベル';

--- a/lang/ru/settings.php
+++ b/lang/ru/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['template'] = 'Шаблон используемый в слайд-шоу';
+$lang['maxHeaderLevelForNewSlide'] = 'Уровень заголовка для нового слайда';

--- a/renderer.php
+++ b/renderer.php
@@ -18,6 +18,7 @@ class renderer_plugin_s5 extends Doku_Renderer_xhtml {
     var $slideopen = false;
     var $base='';
     var $tpl='';
+    var $lastH2='';
 
     /**
      * the format we produce
@@ -121,7 +122,8 @@ class renderer_plugin_s5 extends Doku_Renderer_xhtml {
     /**
      * This is what creates new slides
      *
-     * A new slide is started for each H2 header
+     * A new slide is started for each Hx header,
+     * where x <= configuration parameter "maxHeaderLevelForNewSlide"
      */
     function header($text, $level, $pos) {
         if($level == 1){
@@ -133,12 +135,19 @@ class renderer_plugin_s5 extends Doku_Renderer_xhtml {
             }
         }
 
-        if($level == 2){
+        if($level <= $this->getConf('maxHeaderLevelForNewSlide')){
             if($this->slideopen){
                 $this->doc .= '</div>'.DOKU_LF; //close previous slide
             }
             $this->doc .= '<div class="slide">'.DOKU_LF;
             $this->slideopen = true;
+
+            if ($level == 2) {
+                $this->lastH2 = $text;
+            } else {
+                $level = 2;
+                $text = $this->lastH2 . " - " . $text;
+            }
         }
         $this->doc .= '<h'.($level-1).'>';
         $this->doc .= $this->_xmlEntities($text);
@@ -149,7 +158,7 @@ class renderer_plugin_s5 extends Doku_Renderer_xhtml {
      * Top-Level Sections are slides
      */
     function section_open($level) {
-        if($level < 3){
+        if($level <= $this->getConf('maxHeaderLevelForNewSlide')){
             $this->doc .= '<div class="slidecontent">'.DOKU_LF;
         }else{
             $this->doc .= '<div>'.DOKU_LF;


### PR DESCRIPTION
Implemented the "patch" described in the [plugin's dokuwiki page](https://www.dokuwiki.org/plugin:s5?rev=1467830657) where users can choose which header level splits the slides. I think this is better than having it only split at h1 and h2.

A new metadata configuration has been added where the user can choose the header level that splits the slides. The default is set to '2', which is how they have been rendered before.

Added the description of the config in all available languages.

<3